### PR TITLE
Issue 34: Documentation page build not working

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -75,7 +75,6 @@ extensions = [
     # manually added below extensions
     "myst_parser",
     "sphinx.ext.duration",
-    "renku"
     #"sphinx.ext.autosectionlabel",
     #"recommonmark"
 ]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -75,6 +75,7 @@ extensions = [
     # manually added below extensions
     "myst_parser",
     "sphinx.ext.duration",
+    "renku"
     #"sphinx.ext.autosectionlabel",
     #"recommonmark"
 ]

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,9 +2,10 @@
 # To build the module reference correctly, make sure every external package
 # under `install_requires` in `setup.cfg` is also listed here!
 sphinx>=3.2.1
-# sphinx_rtd_theme
+sphinx_rtd_theme
 pandas
 pytest
 myst-parser
 sphinx_theme
 tk
+renku-sphinx-theme


### PR DESCRIPTION
Build for the Documentation page using the new theme was not working

### Description
Add 2 packages to the requirements.py


### Issue Ticket Number
#34 


